### PR TITLE
Check entities for validity before damaging them

### DIFF
--- a/largeRuins/destroyedEnemyFort.lua
+++ b/largeRuins/destroyedEnemyFort.lua
@@ -30,7 +30,7 @@ return function(center, surface) --destroyed enemy fort
     ce{name = "stone-wall", position = {center.x + (15.0), center.y + (-15.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-16.0), center.y + (-14.0)}, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (-12.5), center.y + (-12.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 2}
     end
     ce{name = "fast-inserter", position = {center.x + (-11.0), center.y + (-13.0)}, direction = direct.west, force = fN}
@@ -50,7 +50,7 @@ return function(center, surface) --destroyed enemy fort
     ce{name = "transport-belt", position = {center.x + (8.0), center.y + (-13.0)}, direction = direct.east, force = fN}
     ce{name = "fast-inserter", position = {center.x + (10.0), center.y + (-13.0)}, direction = direct.west, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (11.5), center.y + (-12.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 2}
     end
     ce{name = "stone-wall", position = {center.x + (15.0), center.y + (-14.0)}, force = fN}
@@ -161,7 +161,7 @@ return function(center, surface) --destroyed enemy fort
     ce{name = "stone-wall", position = {center.x + (15.0), center.y + (11.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-16.0), center.y + (13.0)}, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (-11.5), center.y + (12.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 2}
     end
     ce{name = "transport-belt", position = {center.x + (-7.0), center.y + (13.0)}, direction = direct.west, force = fN}
@@ -181,7 +181,7 @@ return function(center, surface) --destroyed enemy fort
     ce{name = "transport-belt", position = {center.x + (8.0), center.y + (13.0)}, direction = direct.west, force = fN}
     ce{name = "fast-inserter", position = {center.x + (10.0), center.y + (13.0)}, direction = direct.east, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (11.5), center.y + (12.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 2}
     end
     ce{name = "stone-wall", position = {center.x + (15.0), center.y + (12.0)}, force = fN}

--- a/largeRuins/destroyedFort.lua
+++ b/largeRuins/destroyedFort.lua
@@ -40,11 +40,11 @@ return function(center, surface) --destroyed fort
     ce{name = "stone-wall", position = {center.x + (-9.0), center.y + (3.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-9.0), center.y + (2.0)}, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (-7.5), center.y + (2.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 2}
     end
     local e = ce{name = "gun-turret", position = {center.x + (7.5), center.y + (2.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 2}
     end
     ce{name = "stone-wall", position = {center.x + (9.0), center.y + (3.0)}, force = fN}

--- a/mediumRuins/encampment.lua
+++ b/mediumRuins/encampment.lua
@@ -44,7 +44,7 @@ return function(center, surface) --encampment
     ce{name = "stone-wall", position = {center.x + (-3.0), center.y + (0.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-2.0), center.y + (0.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (-1.0), center.y + (1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "raw-fish", count = 30}
     end
     ce{name = "stone-wall", position = {center.x + (-1.0), center.y + (0.0)}, force = fN}

--- a/mediumRuins/overgrownFort.lua
+++ b/mediumRuins/overgrownFort.lua
@@ -37,7 +37,7 @@ return function(center, surface)
     ce{name = "stone-wall", position = {center.x + (-6.0), center.y + (-1.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-1.0), center.y + (0.0)}, force = fN}
     local chest = ce{name = "wooden-chest", position = {center.x + (0.0), center.y + (-1.0)}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "iron-plate", count = math.random(10, 200)}
       chest.insert{name = "copper-plate", count = math.random(10, 200)}
     end
@@ -52,7 +52,7 @@ return function(center, surface)
     ce{name = "stone-wall", position = {center.x + (-6.0), center.y + (2.0)}, force = fN}
     ce{name = "tree-05", position = {center.x + (-1.5), center.y + (1.5)}, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (1.5), center.y + (1.5)}, direction = direct.east, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 5}
     end
     ce{name = "stone-wall", position = {center.x + (0.0), center.y + (2.0)}, force = fN}

--- a/mediumRuins/radarOutpost.lua
+++ b/mediumRuins/radarOutpost.lua
@@ -25,7 +25,7 @@ return function(center, surface)
     ce{name = "stone-wall", position = {center.x + (-6.0), center.y + (0.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-6.0), center.y + (1.0)}, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (-3.5), center.y + (0.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 5}
     end
     ce{name = "medium-electric-pole", position = {center.x + (-2.0), center.y + (0.0)}, force = fN}

--- a/mediumRuins/roughFort.lua
+++ b/mediumRuins/roughFort.lua
@@ -20,7 +20,7 @@ return function(center, surface)
     ce{name = "tree-05", position = {center.x + (-5.5), center.y + (-2.5)}, force = fN}
     ce{name = "medium-electric-pole", position = {center.x + (-4.0), center.y + (-4.0)}, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (2.5), center.y + (-2.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "piercing-rounds-magazine", count = 5}
     end
     ce{name = "tree-05", position = {center.x + (5.5), center.y + (-3.5)}, force = fN}
@@ -38,7 +38,7 @@ return function(center, surface)
     ce{name = "tree-05", position = {center.x + (5.5), center.y + (2.5)}, force = fN}
     ce{name = "tree-05", position = {center.x + (-5.5), center.y + (5.5)}, force = fN}
     local e = ce{name = "gun-turret", position = {center.x + (-2.5), center.y + (4.5)}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "piercing-rounds-magazine", count = 5}
     end
     ce{name = "land-mine", position = {center.x + (4.86328125), center.y + (4.16796875)}, force = game.forces.enemy}

--- a/mediumRuins/storageArea.lua
+++ b/mediumRuins/storageArea.lua
@@ -24,14 +24,14 @@ return function(center, surface)
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (-4.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (-5.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (-6.0), center.y + (-4.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "iron-plate", count = math.random(10, 200)}
     end
     ce{name = "wooden-chest", position = {center.x + (-4.0), center.y + (-5.0)}, force = fN}
     ce{name = "wooden-chest", position = {center.x + (-5.0), center.y + (-4.0)}, force = fN}
     ce{name = "wooden-chest", position = {center.x + (0.0), center.y + (-5.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (1.0), center.y + (-4.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "copper-plate", count = math.random(10, 200)}
     end
     ce{name = "wooden-chest", position = {center.x + (2.0), center.y + (-4.0)}, force = fN}
@@ -40,13 +40,13 @@ return function(center, surface)
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (-2.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (-3.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (-4.0), center.y + (-2.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "steel-plate", count = math.random(10, 200)}
     end
     ce{name = "iron-chest", position = {center.x + (-1.0), center.y + (-3.0)}, force = fN}
     ce{name = "wooden-chest", position = {center.x + (1.0), center.y + (-3.0)}, force = fN}
     local e = ce{name = "iron-chest", position = {center.x + (3.0), center.y + (-3.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "transport-belt", count = math.random(10, 70)}
     end
     ce{name = "iron-chest", position = {center.x + (3.0), center.y + (-2.0)}, force = fN}
@@ -55,12 +55,12 @@ return function(center, surface)
     ce{name = "gate", position = {center.x + (-7.0), center.y + (0.0)}, force = fN}
     ce{name = "gate", position = {center.x + (-7.0), center.y + (-1.0)}, force = fN}
     local e = ce{name = "iron-chest", position = {center.x + (-6.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "iron-plate", count = math.random(10, 200)}
     end
     ce{name = "wooden-chest", position = {center.x + (-5.0), center.y + (0.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (-3.0), center.y + (0.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "iron-ore", count = math.random(50, 200)}
     end
     ce{name = "wooden-chest", position = {center.x + (-1.0), center.y + (-1.0)}, force = fN}
@@ -70,20 +70,20 @@ return function(center, surface)
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (2.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (1.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (-6.0), center.y + (2.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "coal", count = math.random(10, 200)}
     end
     ce{name = "wooden-chest", position = {center.x + (-5.0), center.y + (2.0)}, force = fN}
     ce{name = "wooden-chest", position = {center.x + (-4.0), center.y + (2.0)}, force = fN}
     ce{name = "iron-chest", position = {center.x + (-3.0), center.y + (1.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (0.0), center.y + (1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "stone", count = math.random(10, 200)}
     end
     ce{name = "wooden-chest", position = {center.x + (1.0), center.y + (2.0)}, force = fN}
     ce{name = "wooden-chest", position = {center.x + (1.0), center.y + (1.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (3.0), center.y + (2.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "inserter", count = math.random(10, 20)}
     end
     ce{name = "stone-wall", position = {center.x + (5.0), center.y + (1.0)}, force = fN}
@@ -91,18 +91,18 @@ return function(center, surface)
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (4.0)}, force = fN}
     ce{name = "stone-wall", position = {center.x + (-7.0), center.y + (3.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (-6.0), center.y + (4.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "copper-plate", count = math.random(10, 200)}
     end
     ce{name = "iron-chest", position = {center.x + (-4.0), center.y + (4.0)}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (-3.0), center.y + (3.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "repair-pack", count = math.random(10, 20)}
     end
     ce{name = "wooden-chest", position = {center.x + (-2.0), center.y + (3.0)}, force = fN}
     ce{name = "iron-chest", position = {center.x + (-1.0), center.y + (4.0)}, force = fN}
     local e = ce{name = "iron-chest", position = {center.x + (2.0), center.y + (4.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "gun-turret", count = math.random(10, 20)}
     end
     ce{name = "stone-wall", position = {center.x + (5.0), center.y + (3.0)}, force = fN}

--- a/smallRuins/diagonalWall.lua
+++ b/smallRuins/diagonalWall.lua
@@ -6,38 +6,38 @@ return function(center, surface) --randomly damaged diagonal wall
     end
     local fN = game.forces.neutral
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y + 3.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-1.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-1.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x-0.5, center.y + 1.5}, force = fN}
     ce{name = "stone-wall", position = {center.x-0.5, center.y + 0.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x, center.y}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x + 0.5, center.y-0.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x + 1.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 1.5, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 500),"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x + 2.5, center.y-2.5}, force = fN}

--- a/smallRuins/diagonalWall2.lua
+++ b/smallRuins/diagonalWall2.lua
@@ -6,55 +6,55 @@ return function(center, surface) --randomly damaged diagonal wall
     end
     local fN = game.forces.neutral
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y + 3.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-1.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-1.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-0.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-0.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x, center.y}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 0.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 1.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 1.5, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 3.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(0, 800),"neutral","physical")
     end
 end

--- a/smallRuins/gateWall2.lua
+++ b/smallRuins/gateWall2.lua
@@ -9,7 +9,7 @@ return function(center, surface) --section of wall with gate
 
     ce{name = "gate", position = {center.x + 0.5, center.y-0.5}, force = fN}
     local e = ce{name = "gate", position = {center.x + 0.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(115,"neutral","physical")
     end
 

--- a/smallRuins/gateWall3.lua
+++ b/smallRuins/gateWall3.lua
@@ -6,11 +6,11 @@ return function(center, surface) --section of wall with gate
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "stone-wall", position = {center.x + 0.5, center.y-3.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(68,"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 0.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(82,"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x + 0.5, center.y-1.5}, force = fN}

--- a/smallRuins/gears2.lua
+++ b/smallRuins/gears2.lua
@@ -9,18 +9,18 @@ return function(center, surface) --small gears setup
     ce{name="fast-transport-belt", position={center.x + (-0.0), center.y + (2.0)}, force = fN}
     ce{name="fast-transport-belt", position={center.x + (1.0), center.y + (2.0)}, direction = direct.east, force = fN}
     local e = ce{name="fast-transport-belt", position={center.x + (-2.0), center.y + (3.0)}, direction = direct.east, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(42,"neutral","physical")
     end
     local e = ce{name="fast-transport-belt", position={center.x + (-1.0), center.y + (3.0)}, direction = direct.east, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(18,"neutral","physical")
     end
     ce{name="fast-transport-belt", position={center.x + (-1.0), center.y + (2.0)}, direction = direct.west, force = fN}
     ce{name="fast-transport-belt", position={center.x + (-3.0), center.y + (2.0)}, direction = direct.east, force = fN}
     ce{name="fast-transport-belt", position={center.x + (-3.0), center.y + (3.0)}, direction = direct.south, force = fN}
     local e = ce{name="assembling-machine-2", position={center.x + (2.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(98,"neutral","physical")
     end
     ce{name="medium-electric-pole", position={center.x + (-0.0), center.y + (1.0)}, force = fN}
@@ -28,11 +28,11 @@ return function(center, surface) --small gears setup
     ce{name="assembling-machine-2", position={center.x + (-1.0), center.y + (-1.0)}, force = fN}
     ce{name="fast-inserter", position={center.x + (-1.0), center.y + (1.0)}, direction = direct.south, force = fN}
     local e = ce{name="fast-inserter", position={center.x + (2.0), center.y + (-3.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(36,"neutral","physical")
     end
     local e = ce{name="fast-inserter", position={center.x + (3.0), center.y + (-3.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(50,"neutral","physical")
     end
     ce{name="fast-inserter", position={center.x + (-0.0), center.y + (-3.0)}, direction = direct.south, force = fN}

--- a/smallRuins/harmlessTurret.lua
+++ b/smallRuins/harmlessTurret.lua
@@ -5,7 +5,7 @@ return function(center, surface) --harmless turret
         return surface.create_entity(params)
     end
     local e = ce{name = "gun-turret", position = {center.x + 1, center.y}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.damage(math.random(250, 390),"neutral","physical")
     end
 end

--- a/smallRuins/harmlessTurret2.lua
+++ b/smallRuins/harmlessTurret2.lua
@@ -5,7 +5,7 @@ return function(center, surface) --harmless turret
         return surface.create_entity(params)
     end
     local e = ce{name = "gun-turret", position = {center.x + 1, center.y}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = 1}
     end
 end

--- a/smallRuins/harmlessTurret3.lua
+++ b/smallRuins/harmlessTurret3.lua
@@ -5,69 +5,69 @@ return function(center, surface) --harmless turret
         return surface.create_entity(params)
     end
     local e = ce{name = "gun-turret", position = {center.x, center.y}, force = game.forces.enemy}
-    if e then
+    if e and e.valid then
       e.damage(math.random(50, 200),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-1.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-0.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 0.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x + 1.5, center.y-2.5}, force = fN}
     ce{name = "stone-wall", position = {center.x + 2.5, center.y-2.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x + 2.5, center.y-1.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x-2.5, center.y + 0.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-2.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x-1.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x-0.5, center.y + 2.5}, force = fN}
     ce{name = "stone-wall", position = {center.x + 0.5, center.y + 2.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x + 1.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(math.random(1, 500),"neutral","physical")
     end
 end

--- a/smallRuins/miningSetup2.lua
+++ b/smallRuins/miningSetup2.lua
@@ -8,7 +8,7 @@ return function(center, surface) --mining setup
     local direct = defines.direction
     ce{name = "burner-mining-drill", position = {center.x + (0.5), center.y + (0.5)}, direction = direct.east, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x + (2.0), center.y + (0.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "iron-ore", count = math.random(1, 90)}
     end
 end

--- a/smallRuins/miningSetup3.lua
+++ b/smallRuins/miningSetup3.lua
@@ -7,11 +7,11 @@ return function(center, surface) --mining setup
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "burner-mining-drill", position = {center.x + (0.5), center.y + (0.5)}, direction = direct.north, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(96,"neutral","physical")
     end
     local e = ce{name = "wooden-chest", position = {center.x + (0.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "coal", count = math.random(1, 75)}
     end
 end

--- a/smallRuins/miningSetup4.lua
+++ b/smallRuins/miningSetup4.lua
@@ -8,7 +8,7 @@ return function(center, surface) --mining setup
     local direct = defines.direction
     ce{name = "electric-mining-drill", position = {center.x + (0.0), center.y + (0.0)}, direction = direct.west, force = fN}
     local e = ce{name = "iron-chest", position = {center.x + (-2.0), center.y + (0.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "copper-ore", count = math.random(1, 75)}
     end
 end

--- a/smallRuins/railSection5.lua
+++ b/smallRuins/railSection5.lua
@@ -7,19 +7,19 @@ return function(center, surface) --section of rails
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "straight-rail", position = {center.x + (0.0), center.y + (-8.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(18,"neutral","physical")
     end
     local e = ce{name = "straight-rail", position = {center.x + (0.0), center.y + (-6.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(56,"neutral","physical")
     end
     local e = ce{name = "straight-rail", position = {center.x + (0.0), center.y + (-4.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(33,"neutral","physical")
     end
     local e = ce{name = "straight-rail", position = {center.x + (0.0), center.y + (-2.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(45,"neutral","physical")
     end
     ce{name = "straight-rail", position = {center.x + (0.0), center.y + (0.0)}, force = fN}

--- a/smallRuins/randomWalls2.lua
+++ b/smallRuins/randomWalls2.lua
@@ -8,7 +8,7 @@ return function(center, surface) --random walls
     ce{name = "stone-wall", position = {center.x-2.5, center.y-2.5}, force = fN}
     ce{name = "stone-wall", position = {center.x + 0.5, center.y-2.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x-1.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(12,"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x + 2.5, center.y-0.5}, force = fN}

--- a/smallRuins/randomWalls4.lua
+++ b/smallRuins/randomWalls4.lua
@@ -6,7 +6,7 @@ return function(center, surface) --random walls
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "wooden-chest", position = {center.x, center.y}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "firearm-magazine", count = math.random(1, 300)}
     end
     ce{name = "stone-wall", position = {center.x-2.5, center.y-0.5}, force = fN}
@@ -14,21 +14,21 @@ return function(center, surface) --random walls
     ce{name = "stone-wall", position = {center.x-2.5, center.y + 2.5}, force = fN}
     ce{name = "stone-wall", position = {center.x + 2.5, center.y-0.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(22,"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(46,"neutral","physical")
     end
     local e = ce{name = "stone-wall", position = {center.x + 2.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(68,"neutral","physical")
     end
     ce{name = "stone-wall", position = {center.x-0.5, center.y-2.5}, force = fN}
     ce{name = "stone-wall", position = {center.x + 0.5, center.y-2.5}, force = fN}
     local e = ce{name = "stone-wall", position = {center.x + 0.5, center.y + 2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(25,"neutral","physical")
     end
 end

--- a/smallRuins/researchStation.lua
+++ b/smallRuins/researchStation.lua
@@ -7,7 +7,7 @@ return function(center, surface) --research station
     local fN = game.forces.neutral
     ce{name = "lab", position = {center.x + 1.5, center.y-0.5}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "automation-science-pack", count=20}
     end
 end

--- a/smallRuins/researchStation2.lua
+++ b/smallRuins/researchStation2.lua
@@ -6,11 +6,11 @@ return function(center, surface) --research station
     end
     local fN = game.forces.neutral
     local e = ce{name = "lab", position = {center.x + 1.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(61,"neutral","physical")
     end
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "automation-science-pack", count = math.random(10, 40)}
     end
 end

--- a/smallRuins/researchStation3.lua
+++ b/smallRuins/researchStation3.lua
@@ -6,11 +6,11 @@ return function(center, surface) --research station
     end
     local fN = game.forces.neutral
     local e = ce{name = "lab", position = {center.x + 1.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(25,"neutral","physical")
     end
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "logistic-science-pack", count=50}
     end
 end

--- a/smallRuins/researchStation4.lua
+++ b/smallRuins/researchStation4.lua
@@ -7,7 +7,7 @@ return function(center, surface) --research station
     local fN = game.forces.neutral
     ce{name = "lab", position = {center.x + 1.5, center.y-0.5}, force = fN}
     local chest = ce{name = "wooden-chest", position = {center.x + 1.5, center.y + 1.5}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "automation-science-pack", count = math.random(20, 40)}
       chest.insert{name = "logistic-science-pack", count = math.random(10, 20)}
     end

--- a/smallRuins/researchStation5.lua
+++ b/smallRuins/researchStation5.lua
@@ -7,7 +7,7 @@ return function(center, surface) --research station
     local fN = game.forces.neutral
     ce{name = "lab", position = {center.x + 1.5, center.y-0.5}, force = fN}
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "chemical-science-pack", count = math.random(25, 100)}
     end
 end

--- a/smallRuins/researchStation6.lua
+++ b/smallRuins/researchStation6.lua
@@ -6,7 +6,7 @@ return function(center, surface) --research station
     end
     local fN = game.forces.neutral
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "automation-science-pack", count=10}
     end
 end

--- a/smallRuins/researchStation7.lua
+++ b/smallRuins/researchStation7.lua
@@ -6,7 +6,7 @@ return function(center, surface) --research station
     end
     local fN = game.forces.neutral
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "automation-science-pack", count = math.random(10, 50)}
     end
 end

--- a/smallRuins/researchStation8.lua
+++ b/smallRuins/researchStation8.lua
@@ -6,7 +6,7 @@ return function(center, surface) --research station
     end
     local fN = game.forces.neutral
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "automation-science-pack", count=50}
     end
 end

--- a/smallRuins/researchStation9.lua
+++ b/smallRuins/researchStation9.lua
@@ -6,7 +6,7 @@ return function(center, surface) --research station
     end
     local fN = game.forces.neutral
     local e = ce{name = "wooden-chest", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "logistic-science-pack", count = math.random(40, 100)}
     end
 end

--- a/smallRuins/rockStash.lua
+++ b/smallRuins/rockStash.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "engine-unit", count=8}
       chest.insert{name = "iron-plate", count=20}
       chest.insert{name = "steel-plate", count=5}

--- a/smallRuins/rockStash10.lua
+++ b/smallRuins/rockStash10.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "piercing-rounds-magazine", count = math.random(5, 50)}
     end
     ce{name = "rock-big", position = {center.x, center.y}, force = fN}

--- a/smallRuins/rockStash2.lua
+++ b/smallRuins/rockStash2.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "automation-science-pack", count=20}
     end
     ce{name = "rock-big", position = {center.x, center.y}, force = fN}

--- a/smallRuins/rockStash3.lua
+++ b/smallRuins/rockStash3.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "automation-science-pack", count = math.random(10, 30)}
     end
     ce{name = "rock-big", position = {center.x, center.y}, force = fN}

--- a/smallRuins/rockStash4.lua
+++ b/smallRuins/rockStash4.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "automation-science-pack", count = math.random(1, 20)}
       chest.insert{name = "logistic-science-pack", count = math.random(20, 60)}
     end

--- a/smallRuins/rockStash5.lua
+++ b/smallRuins/rockStash5.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "iron-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "laser-turret", count = math.random(1, 2)}
     end
     ce{name = "rock-big", position = {center.x, center.y}, force = fN}

--- a/smallRuins/rockStash7.lua
+++ b/smallRuins/rockStash7.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "piercing-rounds-magazine", count = math.random(5, 50)}
       chest.insert{name = "shotgun-shell", count = math.random(5, 25)}
     end

--- a/smallRuins/rockStash8.lua
+++ b/smallRuins/rockStash8.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "firearm-magazine", count = math.random(25, 200)}
       chest.insert{name = "shotgun-shell", count = math.random(5, 25)}
     end

--- a/smallRuins/rockStash9.lua
+++ b/smallRuins/rockStash9.lua
@@ -6,7 +6,7 @@ return function(center, surface) --suspicious rock, stash
     end
     local fN = game.forces.neutral
     local chest = ce{name = "wooden-chest", position = {center.x+1, center.y+1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "piercing-shotgun-shell", count = math.random(5, 25)}
     end
     ce{name = "rock-big", position = {center.x, center.y}, force = fN}

--- a/smallRuins/smallDestroyedSetup.lua
+++ b/smallRuins/smallDestroyedSetup.lua
@@ -8,18 +8,18 @@ return function(center, surface) --small destroyed setup
     local direct = defines.direction
     ce{name = "assembling-machine-1", position = {center.x + 0.5, center.y + 2.5}, force = fN}
     local e = ce{name = "inserter", position = {center.x + 2.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(24,"neutral","physical")
     end
     ce{name = "inserter", position = {center.x + 0.5, center.y-1.5}, force = fN}
 
     ce{name = "transport-belt", position = {center.x-1.5, center.y + 1}, force = fN}
     local e = ce{name = "transport-belt", position = {center.x-1.5, center.y}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(17,"neutral","physical")
     end
     local e = ce{name = "transport-belt", position = {center.x-1.5, center.y-1}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(15,"neutral","physical")
     end
 end

--- a/smallRuins/smallDestroyedSetup2.lua
+++ b/smallRuins/smallDestroyedSetup2.lua
@@ -7,25 +7,25 @@ return function(center, surface) --small destroyed setup
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "assembling-machine-1", position = {center.x + 2.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(118,"neutral","physical")
     end
     ce{name = "inserter", position = {center.x + 1.5, center.y + 2.5}, force = fN}
     local e = ce{name = "inserter", position = {center.x-1.5, center.y + 0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(19,"neutral","physical")
     end
 
     local e = ce{name = "transport-belt", position = {center.x + 1, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(12,"neutral","physical")
     end
     local e = ce{name = "transport-belt", position = {center.x, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(29,"neutral","physical")
     end
     local e = ce{name = "transport-belt", position = {center.x-1, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(6,"neutral","physical")
     end
 end

--- a/smallRuins/smallDestroyedSetup3.lua
+++ b/smallRuins/smallDestroyedSetup3.lua
@@ -7,29 +7,29 @@ return function(center, surface) --small destroyed setup
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "assembling-machine-1", position = {center.x-0.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(33,"neutral","physical")
     end
     local e = ce{name = "inserter", position = {center.x-2.5, center.y-1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(106,"neutral","physical")
     end
     local e = ce{name = "inserter", position = {center.x-0.5, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(3,"neutral","physical")
     end
 
     local e = ce{name = "transport-belt", position = {center.x + 1.5, center.y-1}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(14,"neutral","physical")
     end
     local e = ce{name = "transport-belt", position = {center.x + 1.5, center.y}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(21,"neutral","physical")
     end
     ce{name = "transport-belt", position = {center.x + 1.5, center.y + 1}, force = fN}
     local e = ce{name = "transport-belt", position = {center.x + 1.5, center.y + 2}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(36,"neutral","physical")
     end
     ce{name = "transport-belt", position = {center.x + 1.5, center.y + 4}, force = fN}

--- a/smallRuins/smallDestroyedSetup4.lua
+++ b/smallRuins/smallDestroyedSetup4.lua
@@ -7,28 +7,28 @@ return function(center, surface) --small destroyed setup
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "assembling-machine-2", position = {center.x-2.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(193,"neutral","physical")
     end
     local e = ce{name = "inserter", position = {center.x-1.5, center.y-2.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(121,"neutral","physical")
     end
     local e = ce{name = "inserter", position = {center.x + 1.5, center.y-0.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(44,"neutral","physical")
     end
 
     local e = ce{name = "transport-belt", position = {center.x-1, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(67,"neutral","physical")
     end
     local e = ce{name = "transport-belt", position = {center.x, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(92,"neutral","physical")
     end
     local e = ce{name = "transport-belt", position = {center.x + 1, center.y + 1.5}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(85,"neutral","physical")
     end
 end

--- a/smallRuins/smallDualSplitter2.lua
+++ b/smallRuins/smallDualSplitter2.lua
@@ -8,24 +8,24 @@ return function(center, surface) -- small dual splitter
     local direct = defines.direction
 
     local e = ce{name="transport-belt", position={center.x + (1.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(114,"neutral","physical")
     end
     ce{name="splitter", position={center.x + (0.0), center.y + (-0.5)}, direction = direct.west, force = fN}
     local e = ce{name="splitter", position={center.x + (-1.0), center.y + (0.5)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(36,"neutral","physical")
     end
     ce{name="transport-belt", position={center.x + (-2.0), center.y + (1.0)}, direction = direct.west, force = fN}
     ce{name="transport-belt", position={center.x + (-2.0), center.y + (0.0)}, direction = direct.west, force = fN}
     ce{name="transport-belt", position={center.x + (1.0), center.y + (0.0)}, direction = direct.west, force = fN}
     local e = ce{name="transport-belt", position={center.x + (1.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(29,"neutral","physical")
     end
     ce{name="transport-belt", position={center.x + (2.0), center.y + (0.0)}, direction = direct.west, force = fN}
     local e = ce{name="transport-belt", position={center.x + (2.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(56,"neutral","physical")
     end
     ce{name="transport-belt", position={center.x + (3.0), center.y + (0.0)}, direction = direct.west, force = fN}

--- a/smallRuins/smallMining2.lua
+++ b/smallRuins/smallMining2.lua
@@ -11,11 +11,11 @@ return function(center, surface) -- small mining
     ce{name="transport-belt", position={center.x + (-2.0), center.y + (1.0)}, direction = direct.west, force = fN}
     ce{name="transport-belt", position={center.x + (-3.0), center.y + (1.0)}, direction = direct.west, force = fN}
     local e = ce{name="transport-belt", position={center.x + (1.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(15,"neutral","physical")
     end
     local e = ce{name="transport-belt", position={center.x + (2.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(34,"neutral","physical")
     end
 end

--- a/smallRuins/smallMining3.lua
+++ b/smallRuins/smallMining3.lua
@@ -7,15 +7,15 @@ return function(center, surface) -- small mining
     local direct = defines.direction
     ce{name="burner-mining-drill", position={center.x + (-1.5), center.y + (-0.5)}, direction = direct.south, force = fN}
     local e = ce{name="burner-mining-drill", position={center.x + (0.5), center.y + (-0.5)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(99,"neutral","physical")
     end
     local e = ce{name="transport-belt", position={center.x + (-1.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(112,"neutral","physical")
     end
     local e = ce{name="transport-belt", position={center.x + (1.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(138,"neutral","physical")
     end
 end

--- a/smallRuins/smallSmelting.lua
+++ b/smallRuins/smallSmelting.lua
@@ -7,7 +7,7 @@ return function(center, surface)  --small smelting station
     local direct = defines.direction
     ce{name = "stone-furnace", position = {center.x-2, center.y-2}, force = fN}
     local chest = ce{name = "wooden-chest", position = {center.x, center.y-1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "coal", count = math.random(1, 10)}
       chest.insert{name = "iron-ore", count = math.random(1, 40)}
     end

--- a/smallRuins/smallSmelting2.lua
+++ b/smallRuins/smallSmelting2.lua
@@ -7,7 +7,7 @@ return function(center, surface)  --small smelting station
     local direct = defines.direction
     ce{name = "stone-furnace", position = {center.x-2.5, center.y-2.5}, force = fN}
     local chest = ce{name = "wooden-chest", position = {center.x-2, center.y}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "coal", count = math.random(1, 10)}
       chest.insert{name = "copper-ore", count = math.random(1, 40)}
     end

--- a/smallRuins/smallSmelting3.lua
+++ b/smallRuins/smallSmelting3.lua
@@ -7,7 +7,7 @@ return function(center, surface)  --small smelting station
     local direct = defines.direction
     ce{name = "stone-furnace", position = {center.x-2, center.y-2}, force = fN}
     local chest = ce{name = "wooden-chest", position = {center.x, center.y-1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "copper-ore", count = math.random(1, 30)}
       chest.insert{name = "iron-ore", count = math.random(1, 30)}
     end

--- a/smallRuins/smallSmelting4.lua
+++ b/smallRuins/smallSmelting4.lua
@@ -6,11 +6,11 @@ return function(center, surface)  --small smelting station
     local fN = game.forces.neutral
     local direct = defines.direction
     local e = ce{name = "stone-furnace", position = {center.x-2, center.y-2}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(40,"neutral","physical")
     end
     local chest = ce{name = "wooden-chest", position = {center.x, center.y-1}, force = fN}
-    if chest then
+    if chest and chest.valid then
       chest.insert{name = "coal", count = math.random(1, 10)}
       chest.insert{name = "stone", count = math.random(1, 20)}
       chest.insert{name = "iron-ore", count = math.random(1, 15)}

--- a/smallRuins/smeltery.lua
+++ b/smallRuins/smeltery.lua
@@ -8,41 +8,41 @@ return function(center, surface) --smeltery
     local direct = defines.direction
     ce{name="small-electric-pole", position={center.x + (-3.0), center.y + (-2.0)}, force = fN}
     local e = ce{name="stone-furnace", position={center.x + (-1.5), center.y + (-2.5)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(12,"neutral","physical")
     end
     local e = ce{name="stone-furnace", position={center.x + (1.5), center.y + (-2.5)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(19,"neutral","physical")
     end
     local e = ce{name="small-electric-pole", position={center.x + (3.0), center.y + (-2.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(38,"neutral","physical")
     end
     local e = ce{name="small-lamp", position={center.x + (-3.0), center.y + (0.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(62,"neutral","physical")
     end
     ce{name="wooden-chest", position = {center.x + (-3.0), center.y + (-3.0)}, force = game.forces.neutral}
     local e = ce{name="inserter", position={center.x + (-1.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(9,"neutral","physical")
     end
     local e = ce{name="transport-belt", position={center.x + (-1.0), center.y + (0.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(15,"neutral","physical")
     end
     ce{name="inserter", position={center.x + (2.0), center.y + (-1.0)}, force = fN}
     local e = ce{name="transport-belt", position={center.x + (2.0), center.y + (0.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(33,"neutral","physical")
     end
     local e = ce{name="transport-belt", position={center.x + (-3.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(54,"neutral","physical")
     end
     local e = ce{name="transport-belt", position={center.x + (-2.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(20,"neutral","physical")
     end
     ce{name="transport-belt", position={center.x + (-1.0), center.y + (2.0)}, force = fN}

--- a/smallRuins/smeltery2.lua
+++ b/smallRuins/smeltery2.lua
@@ -12,7 +12,7 @@ return function(center, surface) --smeltery
     ce{name="small-electric-pole", position={center.x + (3.0), center.y + (4.0)}, force = fN}
     ce{name="inserter", position={center.x + (-3.0), center.y + (-2.0)}, force = fN}
     local e = ce{name="wooden-chest", position = {center.x + (-3.0), center.y + (-3.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.insert{name = "iron-plate", count = math.random(1, 50)}
     end
     ce{name="inserter", position={center.x + (-1.0), center.y + (-1.0)}, force = fN}

--- a/smallRuins/smeltery3.lua
+++ b/smallRuins/smeltery3.lua
@@ -10,7 +10,7 @@ return function(center, surface) --smeltery
     ce{name="stone-furnace", position={center.x + (1.5), center.y + (4.5)}, force = fN}
     ce{name="small-electric-pole", position={center.x + (3.0), center.y + (-2.0)}, force = fN}
     local e = ce{name="small-electric-pole", position={center.x + (3.0), center.y + (4.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(7,"neutral","physical")
     end
     ce{name="small-lamp", position={center.x + (-3.0), center.y + (0.0)}, force = fN}
@@ -26,19 +26,19 @@ return function(center, surface) --smeltery
     ce{name="fast-transport-belt", position={center.x + (0.0), center.y + (1.0)}, direction = direct.west, force = fN}
     ce{name="fast-transport-belt", position={center.x + (2.0), center.y + (2.0)}, force = fN}
     local e = ce{name="fast-transport-belt", position={center.x + (1.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(14,"neutral","physical")
     end
     local e = ce{name="fast-transport-belt", position={center.x + (2.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(35,"neutral","physical")
     end
     local e = ce{name="fast-transport-belt", position={center.x + (3.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(84,"neutral","physical")
     end
     local e = ce{name="fast-inserter", position={center.x + (-1.0), center.y + (3.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(49,"neutral","physical")
     end
     ce{name="fast-inserter", position={center.x + (2.0), center.y + (3.0)}, direction = direct.south, force = fN}

--- a/smallRuins/smeltery4.lua
+++ b/smallRuins/smeltery4.lua
@@ -8,40 +8,40 @@ return function(center, surface) --smeltery
     local direct = defines.direction
     ce{name="medium-electric-pole", position={center.x + (-3.0), center.y + (-2.0)}, force = fN}
     local e = ce{name="medium-electric-pole", position={center.x + (-3.0), center.y + (4.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(30,"neutral","physical")
     end
     ce{name="stone-furnace", position={center.x + (1.5), center.y + (-2.5)}, force = fN}
     local e = ce{name="stone-furnace", position={center.x + (-1.5), center.y + (4.5)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(15,"neutral","physical")
     end
     local e = ce{name="wooden-chest", position = {center.x + (-3.0), center.y + (-3.0)}, force = game.forces.neutral}
-    if e then
+    if e and e.valid then
       e.insert{name = "copper-plate", count = math.random(1, 40)}
     end
     local e = ce{name="inserter", position={center.x + (-1.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(60,"neutral","physical")
     end
     local e = ce{name="transport-belt", position={center.x + (-1.0), center.y + (0.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(45,"neutral","physical")
     end
     local e = ce{name="inserter", position={center.x + (2.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(45,"neutral","physical")
     end
     ce{name="transport-belt", position={center.x + (2.0), center.y + (0.0)}, direction = direct.south, force = fN}
     local e = ce{name="transport-belt", position={center.x + (-3.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(75,"neutral","physical")
     end
     ce{name="transport-belt", position={center.x + (-2.0), center.y + (1.0)}, direction = direct.west, force = fN}
     ce{name="transport-belt", position={center.x + (-1.0), center.y + (2.0)}, force = fN}
     ce{name="transport-belt", position={center.x + (-1.0), center.y + (1.0)}, direction = direct.west, force = fN}
     local e = ce{name="transport-belt", position={center.x + (0.0), center.y + (1.0)}, direction = direct.west, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(30,"neutral","physical")
     end
     ce{name="transport-belt", position={center.x + (2.0), center.y + (2.0)}, force = fN}

--- a/smallRuins/splitterI2.lua
+++ b/smallRuins/splitterI2.lua
@@ -9,11 +9,11 @@ return function(center, surface) --I of splitters
 
     ce{name = "splitter", position = {center.x + (-0.5), center.y + (-2.0)}, direction = direct.south, force = fN}
     local e = ce{name = "splitter", position = {center.x + (1.5), center.y + (-2.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(17,"neutral","physical")
     end
     local e = ce{name = "splitter", position = {center.x + (1.5), center.y + (0.0)}, direction = direct.south, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(44,"neutral","physical")
     end
     ce{name = "splitter", position = {center.x + (0.5), center.y + (1.0)}, direction = direct.south, force = fN}

--- a/smallRuins/victoryPoles3.lua
+++ b/smallRuins/victoryPoles3.lua
@@ -6,7 +6,7 @@ return function(center, surface) --victory poles
     end
     local fN = game.forces.neutral
     local e = ce{name = "medium-electric-pole", position = {center.x + (-2.0), center.y + (0.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(82,"neutral","physical")
     end
     ce{name = "medium-electric-pole", position = {center.x + (0.0), center.y + (-1.0)}, force = fN}

--- a/smallRuins/victoryPoles6.lua
+++ b/smallRuins/victoryPoles6.lua
@@ -8,7 +8,7 @@ return function(center, surface) --victory poles
     ce{name = "small-electric-pole", position = {center.x + (0.0), center.y + (-2.0)}, force = fN}
     ce{name = "small-electric-pole", position = {center.x + (0.0), center.y + (1.0)}, force = fN}
     local e = ce{name="small-lamp", position={center.x + (1.0), center.y + (1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(44,"neutral","physical")
     end
 end

--- a/smallRuins/victoryPoles7.lua
+++ b/smallRuins/victoryPoles7.lua
@@ -6,7 +6,7 @@ return function(center, surface) --victory poles
     end
     local fN = game.forces.neutral
     local e = ce{name = "small-electric-pole", position = {center.x + (0.0), center.y + (-1.0)}, force = fN}
-    if e then
+    if e and e.valid then
       e.damage(26,"neutral","physical")
     end
 end


### PR DESCRIPTION
I'm playing around with killing a random subset of spawned entities in order to get the nice remnant looks added in 18. However, I noticed that if I killed an entity before it was damaged, the damage call blew up and crashed the game, as a dead entity is invalid.

To guard against cases like this, this pr adds an additional `valid` sanity check before calling functions on any created entities. Not sure it's wanted, but I figured I'd send it anyway.